### PR TITLE
Fixed _isDisabledButtonLeft

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ class InputSpinner extends Component {
 	 * @private
 	 */
 	_isDisabledButtonLeft(){
-		return (this.props.disabled || this.props.buttonRightDisabled);
+		return (this.props.disabled || this.props.buttonLeftDisabled);
 	}
 
 	/**


### PR DESCRIPTION
previously _isDisabledButtonLeft was checking whether the right button was disabled, not the left one, so when the right button was set as disabled, both would be.