### PR TITLE
Removed console.log colour printing

### DIFF
--- a/src/InputSpinner.js
+++ b/src/InputSpinner.js
@@ -522,8 +522,6 @@ class InputSpinner extends Component {
 		let parse = parseColor(textColor);
 		parse[3] = Math.round(0.6 * 255);
 
-		console.log(colorsToHex(parse));
-
 		return colorsToHex(parse);
 	}
 


### PR DESCRIPTION
In getPlaceholderColor() in InputSpinner.js; leads to repeated printing of "#00000099". See issue https://github.com/marcocesarato/react-native-input-spinner/issues/46