### PR TITLE
feat: Support button Text props

### DIFF
--- a/src/InputSpinner.js
+++ b/src/InputSpinner.js
@@ -1192,7 +1192,7 @@ class InputSpinner extends Component {
 					: this.props.buttonLeftText
 					? this.props.buttonLeftText
 					: "-";
-			return <Text style={this._getStyleLeftButtonText()}>{text}</Text>;
+			return <Text {...this.props.buttonTextProps} style={this._getStyleLeftButtonText()}>{text}</Text>;
 		}
 	}
 
@@ -1216,7 +1216,7 @@ class InputSpinner extends Component {
 					: this.props.buttonRightText
 					? this.props.buttonRightText
 					: "+";
-			return <Text style={this._getStyleRightButtonText()}>{text}</Text>;
+			return <Text {...this.props.buttonTextProps} style={this._getStyleRightButtonText()}>{text}</Text>;
 		}
 	}
 
@@ -1450,6 +1450,7 @@ InputSpinner.propTypes = {
 	inputProps: PropTypes.object,
 	leftButtonProps: PropTypes.object,
 	rightButtonProps: PropTypes.object,
+	buttonTextProps: PropTypes.object,
 };
 
 InputSpinner.defaultProps = {
@@ -1510,6 +1511,7 @@ InputSpinner.defaultProps = {
 	inputProps: null,
 	leftButtonProps: null,
 	rightButtonProps: null,
+	buttonTextProps: null,
 };
 
 export default InputSpinner;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import React, {Component} from "react";
-import {StyleProp, ViewStyle} from "react-native";
+import {StyleProp, TextProps, ViewStyle} from "react-native";
 
 export interface ReactNativeInputSpinnerProps {
 	type?: string;
@@ -78,5 +78,6 @@ export interface ReactNativeInputSpinnerProps {
 	inputProps?: object;
 	leftButtonProps?: object;
 	rightButtonProps?: object;
+	buttonTextProps?: TextProps;
 }
 export default class InputSpinner extends Component<ReactNativeInputSpinnerProps> {}


### PR DESCRIPTION
Hi,

thanks for maintaining this useful component!

I added support for passing props to the button `Text` component
It supports code completion as `buttonTextProps` is typed as `TextProps`
I can also help update the README if you find this PR useful and plan to merge it

I needed this since devices using font scaling caused the `-` and `+` in the `InputSpinner` buttons to look weird

Example:

```typescript
      <InputSpinner
        step={1}
        value={valueState}
        onChange={handleOnChange}
        buttonTextProps={{ maxFontSizeMultiplier: 1 }}
      />
```