### PR TITLE
Fix spinner for ranges that span 0

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -9,6 +9,7 @@ export const isEmpty = (x) => {
 		return x === "";
 	}
 
+	if (x===0) return false;
 	if (!x) return true;
 	if (x === {}) return true;
 	if (x === []) return true;


### PR DESCRIPTION
define 0 as not an empty value.
This Util function caused ranges that cross 0 to go haywire by setting
the value to the minValue when it hit 0.

Fixes #60 