### PR TITLE
feat: added delayPressIn and delayPressOut properties

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -39,6 +39,10 @@ export default class App extends Component {
 						Example{"\n"}react-native-input-spinner
 					</Text>
 					<View style={Styles.col}>
+						<Text style={Styles.text}>Prevent auto increment on scroll</Text>
+						<InputSpinner value={this.state.value} style={Styles.spinner} delayPressIn={100}/>
+					</View>
+					<View style={Styles.col}>
 						<Text style={Styles.text}>Standard</Text>
 						<InputSpinner value={this.state.value} style={Styles.spinner} />
 					</View>

--- a/src/InputSpinner.js
+++ b/src/InputSpinner.js
@@ -25,6 +25,8 @@ import {
  */
 export const defaultSpeed = 7;
 export const defaultAccelerationDelay = 1000;
+export const defaultDelayPressIn = 0;
+export const defaultDelayPressOut = 0;
 export const defaultTypingTime = 500;
 
 /**
@@ -1260,7 +1262,9 @@ class InputSpinner extends Component {
 				disabled={this._isDisabledButtonLeft()}
 				style={buttonStyle}
 				onPressIn={this.decrease.bind(this)}
+				delayPressIn={this.props.delayPressIn}
 				onPressOut={this.onPressOut.bind(this)}
+				delayPressOut={this.props.delayPressOut}
 				onLongPress={this.decreaseHold.bind(this)}
 				delayLongPress={this.props.accelerationDelay}
 				{...this.props.leftButtonProps}>
@@ -1300,7 +1304,9 @@ class InputSpinner extends Component {
 				disabled={this._isDisabledButtonRight()}
 				style={buttonStyle}
 				onPressIn={this.increase.bind(this)}
+				delayPressIn={this.props.delayPressIn}
 				onPressOut={this.onPressOut.bind(this)}
+				delayPressOut={this.props.delayPressOut}
 				onLongPress={this.increaseHold.bind(this)}
 				delayLongPress={this.props.accelerationDelay}
 				{...this.props.rightButtonProps}>
@@ -1502,6 +1508,8 @@ InputSpinner.defaultProps = {
 	width: "auto",
 	height: 50,
 	accelerationDelay: defaultAccelerationDelay,
+	delayPressIn: defaultDelayPressIn,
+	delayPressOut: defaultDelayPressOut,
 	speed: defaultSpeed,
 	emptied: false,
 	continuity: false,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,6 +53,8 @@ export interface ReactNativeInputSpinnerProps {
 	onSubmit?(...args: unknown[]): unknown;
 	onLongPress?(...args: unknown[]): unknown;
 	accelerationDelay?: number;
+	delayPressIn?: number,
+	delayPressOut?: number,
 	speed?: number;
 	emptied?: boolean;
 	continuity?: boolean;


### PR DESCRIPTION
Exposed delayPressIn and delayPressOut properties. Used delayPressIn property to prevent auto increment on scrolling

[[https://github.com/marcocesarato/react-native-input-spinner/issues/95](url)](https://github.com/marcocesarato/react-native-input-spinner/issues/95)